### PR TITLE
Add workaround for skipped breakpoints

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2581,6 +2581,8 @@ module Kernel
         ::DEBUGGER__::SESSION.add_preset_commands cmds[0], commands, kick: false, continue: false
       end
     else
+      # Workaround for https://github.com/ruby/debug/issues/900
+      cmds.pop if cmds == ["#debugger", nil, "eval $stdout.sync=true"]
       loc = caller_locations(up_level, 1).first; ::DEBUGGER__.add_line_breakpoint loc.path, loc.lineno + 1, oneshot: true, command: cmds
     end
     self


### PR DESCRIPTION
See https://github.com/ruby/debug/issues/900