### PR TITLE
Improve DAP's command execution patch

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -442,8 +442,10 @@ module DEBUGGER__
                           variablesReference: 0
             # Workaround for https://github.com/ruby/debug/issues/900
             # See https://github.com/Shopify/debug/pull/4 for more details
-            commands = [dbg_expr.split(';;').join("\n")]
-            ::DEBUGGER__::SESSION.add_preset_commands '#debugger', commands, kick: false, continue: false
+            commands = dbg_expr.split(';;')
+            commands.each do |cmd|
+              @q_msg << cmd
+            end
           else
             @q_msg << req
           end

--- a/test/protocol/eval_test.rb
+++ b/test/protocol/eval_test.rb
@@ -28,9 +28,11 @@ module DEBUGGER__
       run_protocol_scenario PROGRAM, cdp: false do
         req_add_breakpoint 3
         req_continue
-        send_evaluate_request(",b 5")
+        send_evaluate_request(",b 5 ;; b 6")
         req_continue
         assert_line_num 5
+        req_continue
+        assert_line_num 6
         req_terminate_debuggee
       end
     end
@@ -45,11 +47,6 @@ module DEBUGGER__
                     expression: expression,
                     frameId: f_id,
                     context: "repl"
-      # the preset command we add in the previous request needs to be triggered
-      # by another session action (request in this case).
-      # in VS Code this naturally happens because it'll send a Scope request follow the
-      # evaluate request, but in our test we need to do it manually.
-      send_dap_request 'scopes', frameId: f_id
     end
   end
 end


### PR DESCRIPTION
We actually don't need to use preset commands for executing the DAP's repl commands. Since we have access to the SESSION's message queue `@q_msg`, which directly takes commands, we can just pass the command to the queue.

I also think there should be a fundamental change on how the session handles its operations. This is what the debugger does with our patch from #4:

**On the session side**

a. [`Session#wait_command_loop`](https://github.com/ruby/debug/blob/733dd4b464191e147f00fe767f3c6dcd6ae2c6b9/lib/debug/session.rb#L375) would be called whenever it's ready to serve the next command, which would call [`wait_command`](https://github.com/ruby/debug/blob/733dd4b464191e147f00fe767f3c6dcd6ae2c6b9/lib/debug/session.rb#L399)
b1. If there's no preset command, `#wait_command` would hang waiting for [`@ui.readline`](https://github.com/ruby/debug/blob/733dd4b464191e147f00fe767f3c6dcd6ae2c6b9/lib/debug/session.rb#L417)
b2. If there's a present command(s), `#wait_command` would [pick them up and execute it](https://github.com/ruby/debug/blob/733dd4b464191e147f00fe767f3c6dcd6ae2c6b9/lib/debug/session.rb#L412)
c. Once b) finishes, we enter the next loop in a)

**On the server side (a different thread)**

Req 1. With the `evaluate` request, we add the command (e.g. `eval foo = 1`) as a preset command. And because the request finishes without sending any command to the session, it'd still hang on waiting the `@ui.readline` (see b). As a result, the preset command isn't picked up even after the request is finished
Req 2. The next request comes in and enqueues a message to `@q_msg` (e.g. [`stackTrace`](https://github.com/ruby/debug/blob/master/lib/debug/server_dap.rb#L447-L452))
Req 3. Another request comes in and enqueues a message to `@q_msg` (e.g. [`stackTrace`](https://github.com/ruby/debug/blob/master/lib/debug/server_dap.rb#L447-L452))

**How they work altogether**

1. `a`
1. `b1`
1. `Req 1` - adds `eval foo = 1` to preset command
1. `Req 2` - unblocks `b1` and the request would be executed right away
1. `c` 
1. `a`
1. `b2` - `eval foo = 1` being picked up
1. `c`
1. `a`
1. `b1`
1. `Req 3` - unblocks `b1`
1. `c`
1. `a`

As you can see, using preset commands (which the upstream's [`debugger` method implementation also calls sometimes](https://github.com/ruby/debug/blob/733dd4b464191e147f00fe767f3c6dcd6ae2c6b9/lib/debug/session.rb#L2579-L2582)), commands can be queued and executed in a non-intuitive order. 

So in this PR, I simplified it to just

1. `a`
1. `b1`
1. `Req 1` - ~~adds `eval foo = 1` to preset command~~ Just pass it to `@q_msg`, which unblocks `b1`
1. `c` 
1. `a`
1.  `b1`
1. `Req 2` - unblocks `b1` and the request would be executed right away
1. `c`
1. `a`
1. `b1`
1. `Req 3` - unblocks `b1`
1. `c`
1. `a`
