### PR TITLE
Merge v1.7.2

### DIFF
--- a/.github/workflows/test_test.yml
+++ b/.github/workflows/test_test.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: TestTestFramework
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.0', '3.1', '3.2', 'head', 'debug']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: |
+        bundle exec rake clobber
+        bundle exec rake compile
+        bundle exec rake test_test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,10 +149,10 @@ If the file already exists, **only method** will be added to it.
 ```ruby
 # frozen_string_literal: true
 
-require_relative '../support/test_case'
+require_relative '../support/console_test_case'
 
 module DEBUGGER__
-  class FooTest < TestCase
+  class FooTest < ConsoleTestCase
     def program
       <<~RUBY
         1| module Foo

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ New debug.rb has several advantages:
   * Support threads (almost done) and ractors (TODO).
   * Support suspending and entering to the console debugging with `Ctrl-C` at most of timing.
   * Show parameters on backtrace command.
-  * Support recording & reply debugging.
+  * Support recording & replay debugging.
 
 # Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -35,9 +35,14 @@ task :check_readme do
   end
 end
 
+desc "Run debug.gem test-framework tests"
+Rake::TestTask.new(:test_test) do |t|
+  t.test_files = FileList["test/support/*_test.rb"]
+end
+
 desc "Run all debugger console related tests"
 Rake::TestTask.new(:test_console) do |t|
-  t.test_files = FileList["test/console/*_test.rb", "test/support/*_test.rb"]
+  t.test_files = FileList["test/console/*_test.rb"]
 end
 
 desc "Run all debugger protocols (CAP & DAP) related tests"
@@ -49,4 +54,4 @@ task test: 'test_console' do
   warn '`rake test` doesn\'t run protocol tests. Use `rake test_all` to test all.'
 end
 
-task test_all: [:test_console, :test_protocol]
+task test_all: [:test_test, :test_console, :test_protocol]

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -101,10 +101,6 @@ module DEBUGGER__
     def generate_label(name)
       colorize(" BP - #{name} ", [:YELLOW, :BOLD, :REVERSE])
     end
-
-    def pending_until_load?
-      false
-    end
   end
 
   if RUBY_VERSION.to_f <= 2.7
@@ -163,10 +159,6 @@ module DEBUGGER__
       @pending = !@iseq
     end
 
-    def pending_until_load?
-      @pending
-    end
-
     def setup
       return unless @type
 
@@ -207,6 +199,8 @@ module DEBUGGER__
       if @pending && !@oneshot
         DEBUGGER__.info "#{self} is activated."
       end
+
+      @pending = false
     end
 
     def activate_exact iseq, events, line
@@ -298,6 +292,10 @@ module DEBUGGER__
 
     def inspect
       "<#{self.class.name} #{self.to_s}>"
+    end
+
+    def path_is? path
+      DEBUGGER__.compare_path(@path, path)
     end
   end
 

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -406,14 +406,13 @@ module DEBUGGER__
       require_relative 'server_cdp'
 
       @uuid = SecureRandom.uuid
-      unless @chrome_pid = UI_CDP.setup_chrome(@local_addr.inspect_sockaddr, @uuid)
-        DEBUGGER__.warn <<~EOS
-          With Chrome browser, type the following URL in the address-bar:
+      @chrome_pid = UI_CDP.setup_chrome(@local_addr.inspect_sockaddr, @uuid)
+      DEBUGGER__.warn <<~EOS
+        With Chrome browser, type the following URL in the address-bar:
 
-             devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&ws=#{@local_addr.inspect_sockaddr}/#{@uuid}
+           devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&ws=#{@local_addr.inspect_sockaddr}/#{@uuid}
 
-          EOS
-      end
+        EOS
     end
 
     def accept

--- a/lib/debug/source_repository.rb
+++ b/lib/debug/source_repository.rb
@@ -34,7 +34,7 @@ module DEBUGGER__
       end
 
       def add iseq, src
-        # do nothing
+        # only manage loaded file names
         if (path = (iseq.absolute_path || iseq.path)) && File.exist?(path)
           if @loaded_file_map.has_key? path
             return path, true # reloaded
@@ -49,7 +49,7 @@ module DEBUGGER__
         lines = iseq.script_lines&.map(&:chomp)
         line = iseq.first_line
         if line > 1
-          lines = [*([''] * (line - 1)), *lines]
+          [*([''] * (line - 1)), *lines]
         else
           lines
         end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -1230,7 +1230,15 @@ module DEBUGGER__
     rescue SuspendReplay, SystemExit, Interrupt
       raise
     rescue Exception => e
-      pp ["DEBUGGER Exception: #{__FILE__}:#{__LINE__}", e, e.backtrace]
+      STDERR.puts e.cause.inspect
+      STDERR.puts e.inspect
+      Thread.list.each{|th|
+        STDERR.puts "@@@ #{th}"
+        th.backtrace.each{|b|
+          STDERR.puts " > #{b}"
+        }
+      }
+      p ["DEBUGGER Exception: #{__FILE__}:#{__LINE__}", e, e.backtrace]
       raise
     ensure
       @returning = false

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -54,6 +54,10 @@ module DEBUGGER__
       @tracer.disable
     end
 
+    def enabled?
+      @tracer.enabled?
+    end
+
     def description
       nil
     end
@@ -83,11 +87,6 @@ module DEBUGGER__
         @output.puts buff
         @output.flush
       end
-    end
-
-    def puts msg
-      @output.puts msg
-      @output.flush
     end
 
     def minfo tp

--- a/lib/debug/version.rb
+++ b/lib/debug/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DEBUGGER__
-  VERSION = "1.7.1"
+  VERSION = "1.7.2"
 end

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -26,7 +26,7 @@ New debug.rb has several advantages:
   * Support threads (almost done) and ractors (TODO).
   * Support suspending and entering to the console debugging with `Ctrl-C` at most of timing.
   * Show parameters on backtrace command.
-  * Support recording & reply debugging.
+  * Support recording & replay debugging.
 
 # Installation
 

--- a/test/console/backtrace_test.rb
+++ b/test/console/backtrace_test.rb
@@ -136,7 +136,7 @@ module DEBUGGER__
         omit "Skip test with load files. Cannot create files in HOME directory."
       end
 
-      file = File.open(foo_path, 'w+') { |f| f.write(foo_file) }
+      File.open(foo_path, 'w+') { |f| f.write(foo_file) }
       debug_code(program) do
         type 'c'
         type 'bt'

--- a/test/console/color_test.rb
+++ b/test/console/color_test.rb
@@ -94,7 +94,7 @@ module DEBUGGER__
       CONFIG[:no_color] = nil
     end
 
-    SESSION_class = Struct.new('SESSION')
+    SESSION_class = Struct.new('SESSION', :a)
 
     private
 

--- a/test/console/daemon_test.rb
+++ b/test/console/daemon_test.rb
@@ -4,20 +4,38 @@ require_relative '../support/console_test_case'
 
 module DEBUGGER__
   class DaemonTest < ConsoleTestCase
-    def program
+
+    def test_daemon
       # Ignore SIGHUP since the test debuggee receives SIGHUP after Process.daemon.
       # When manualy debugging a daemon, it doesn't receive SIGHUP.
       # I don't know why.
-      <<~'RUBY'
+      program = <<~'RUBY'
         1| trap(:HUP, 'IGNORE')
         2| puts 'Daemon starting'
         3| Process.daemon
         4| puts 'Daemon started'
       RUBY
+
+      # The program can't be debugged locally since the parent process exits when Process.daemon is called.
+      debug_code program, remote: :remote_only do
+        type 'b 3'
+        type 'c'
+        assert_line_num 3
+        type 'b 4'
+        type 'c'
+        assert_line_num 4
+        type 'c'
+      end
     end
 
-    def test_daemon
-      # The program can't be debugged locally since the parent process exits when Process.daemon is called.
+    def test_daemon_patch
+      program = <<~'RUBY'
+        1| trap(:HUP, 'IGNORE')
+        2| puts 'Daemon starting'
+        3| Process.daemon(false, false)
+        4| puts 'Daemon started'
+      RUBY
+
       debug_code program, remote: :remote_only do
         type 'b 3'
         type 'c'

--- a/test/console/eval_test.rb
+++ b/test/console/eval_test.rb
@@ -35,4 +35,30 @@ module DEBUGGER__
       end
     end
   end
+
+  class EvalThreadTest < ConsoleTestCase
+    def program
+      <<~RUBY
+      1| th0 = Thread.new{sleep}
+      2| m = Mutex.new; q = Queue.new
+      3| th1 = Thread.new do
+      4|   m.lock; q << true
+      5|   sleep 1
+      6|   m.unlock
+      7| end
+      8| q.pop # wait for locking
+      9| p :ok
+      RUBY
+    end
+
+    def test_eval_with_threads
+      debug_code program do
+        type 'b 9'
+        type 'c'
+        type 'm.lock.nil?'
+        assert_line_text 'false'
+        type 'c'
+      end
+    end
+  end
 end

--- a/test/console/trace_test.rb
+++ b/test/console/trace_test.rb
@@ -532,5 +532,31 @@ module DEBUGGER__
         end
       end
     end
+
+    class TraceOnAfterStoppingOnceTest < ConsoleTestCase
+      def program
+        <<~RUBY
+          1| a=1
+          2|
+          3| b=1
+          4|
+          5| c=1
+          6| p a
+        RUBY
+      end
+  
+      def test_1656237686
+        debug_code(program) do
+          type 'trace line'
+          type 'trace off'
+          type 'trace line'
+          type 'b 5'
+          type 'c'
+          assert_line_num 5
+          assert_line_text(/DEBUGGER \(trace\/line\)/)
+          type 'kill!'
+        end
+      end
+    end
   end
 end

--- a/test/protocol/eval_test.rb
+++ b/test/protocol/eval_test.rb
@@ -23,5 +23,38 @@ module DEBUGGER__
         req_terminate_debuggee
       end
     end
+
+    def test_eval_executes_commands
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_add_breakpoint 3
+        req_continue
+        assert_repl_result({value: '(rdbg:command) b 5 ;; b 6', type: nil}, ",b 5 ;; b 6")
+        req_continue
+        assert_line_num 5
+        req_continue
+        assert_line_num 6
+        req_terminate_debuggee
+      end
+    end
+  end
+
+  class EvaluateOnSomeFramesTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| a = 2
+      2| def foo
+      3|   a = 4
+      4| end
+      5| foo
+    RUBY
+
+    def test_eval_evaluates_arithmetic_expressions
+      run_protocol_scenario PROGRAM do
+        req_add_breakpoint 4
+        req_continue
+        assert_repl_result({value: '4', type: 'Integer'}, 'a', frame_idx: 0)
+        assert_repl_result({value: '2', type: 'Integer'}, 'a', frame_idx: 1)
+        req_terminate_debuggee
+      end
+    end
   end
 end

--- a/test/protocol/variables_test.rb
+++ b/test/protocol/variables_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative "../support/protocol_test_case"
+
+module DEBUGGER__
+  class DAPGlobalVariablesTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| $a = 1
+      2| $b = 2
+      3| $c = 3
+    RUBY
+
+    def test_eval_evaluates_global_variables
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_add_breakpoint 3
+        req_continue
+
+        globals = gather_variables(type: "globals")
+
+        # User defined globals
+        assert_includes(globals, { name: "$a", value: "1", type: "Integer", variablesReference: 0 })
+        assert_includes(globals, { name: "$b", value: "2", type: "Integer", variablesReference: 0 })
+
+        # Ruby defined globals
+        assert_includes(globals, { name: "$VERBOSE", value: "false", type: "FalseClass", variablesReference: 0 })
+        assert_includes(globals, { name: "$stdout", value: "#<IO:<STDOUT>>", type: "IO", variablesReference: 0 })
+
+        req_terminate_debuggee
+      end
+    end
+  end
+
+  class CDPGlobalVariablesTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| $a = 1
+      2| $b = 2
+      3| $c = 3
+    RUBY
+
+    def test_eval_evaluates_global_variables
+      run_protocol_scenario PROGRAM, dap: false do
+        req_add_breakpoint 3
+        req_continue
+
+        globals = gather_variables(type: "global")
+
+        # User defined globals
+        assert_includes(globals, { name: "$a", value: "1", type: "Number" })
+        assert_includes(globals, { name: "$b", value: "2", type: "Number" })
+
+        # Ruby defined globals
+        assert_includes(globals, { name: "$VERBOSE", value: "false", type: "Boolean" })
+        assert_includes(globals, { name: "$stdout", value: "#<IO:<STDOUT>>", type: "Object" })
+
+        req_terminate_debuggee
+      end
+    end
+  end
+
+  class DAPInstanceVariableTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| @a = 1
+      2| @c = 3
+      3| @b = 2
+      4| __LINE__
+    RUBY
+
+    def test_ordering_instance_variables
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_add_breakpoint 4
+        req_continue
+
+        locals = gather_variables
+
+        variables_reference = locals.find { |local| local[:name] == "%self" }[:variablesReference]
+        res = send_dap_request 'variables', variablesReference: variables_reference
+
+        instance_vars = res.dig(:body, :variables)
+        assert_equal instance_vars.map { |var| var[:name] }, ["#class", "@a", "@b", "@c"]
+
+        req_terminate_debuggee
+      end
+    end
+  end
+end

--- a/test/support/assertions_test.rb
+++ b/test/support/assertions_test.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
     def test_the_helper_takes_a_string_expectation_and_escape_it
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           assert_line_text("foobar?")
         end
       end
@@ -51,6 +51,8 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_unix_domain_socket_mode_doesnt_exist_after_scenarios
+      omit "too slow now"
+
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
         prepare_test_environment(program, steps) do
           debug_code_on_unix_domain_socket()
@@ -59,6 +61,8 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_tcpip_mode_doesnt_exist_after_scenarios
+      omit "too slow now"
+
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
         prepare_test_environment(program, steps) do
           debug_code_on_tcpip()

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -86,7 +86,7 @@ module DEBUGGER__
     end
 
     def debug_code(program, remote: true, &test_steps)
-      Timeout.timeout(30) do
+      Timeout.timeout(60) do
         prepare_test_environment(program, test_steps) do
           if remote && !NO_REMOTE && MULTITHREADED_TEST
             begin
@@ -200,7 +200,7 @@ module DEBUGGER__
           # kill debug console process
           read.close
           write.close
-          kill_safely pid, :debugger, test_info
+          kill_safely pid
         end
       end
     end

--- a/test/support/protocol_test_case_test.rb
+++ b/test/support/protocol_test_case_test.rb
@@ -3,14 +3,33 @@
 require_relative 'protocol_test_case'
 
 module DEBUGGER__
-  class TestFrameworkTestHOge < ProtocolTestCase
-    PROGRAM = <<~RUBY
-      1| a=1
-    RUBY
-
+  class TestProtocolTestCase < ProtocolTestCase
     def test_the_test_fails_when_debuggee_doesnt_exit
+      omit "too slow now"
+
+      program = <<~RUBY
+        1| a=1
+      RUBY
+
       assert_fail_assertion do
-        run_protocol_scenario PROGRAM do
+        run_protocol_scenario program do
+        end
+      end
+    end
+
+    def test_the_assertion_failure_takes_presedence_over_debuggee_not_exiting
+      omit "too slow now"
+
+      program = <<~RUBY
+        1| a = 2
+        2| b = 3
+      RUBY
+
+      assert_raise_message(/<\"100\"> expected but was/) do
+        run_protocol_scenario program do
+          req_add_breakpoint 2
+          req_continue
+          assert_repl_result({value: '100', type: 'Integer'}, 'a')
         end
       end
     end

--- a/test/support/test_case_test.rb
+++ b/test/support/test_case_test.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
     def test_the_test_fails_when_debugger_exits_early
       assert_raise_message(/Expected all commands\/assertions to be executed/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           type 'continue'
           type 'foo'
         end
@@ -35,7 +35,7 @@ module DEBUGGER__
 
     def test_the_test_fails_when_the_repl_prompt_does_not_finish_even_though_scenario_is_empty
       assert_raise_message(/Expected the REPL prompt to finish/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
         end
       end
     end
@@ -61,6 +61,8 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_unix_domain_socket_mode_doesnt_exist_after_scenarios
+      omit "too slow now"
+
       assert_raise_message(/Expected the debuggee program to finish/) do
         prepare_test_environment(program, steps) do
           debug_code_on_unix_domain_socket()
@@ -69,6 +71,8 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_tcpip_mode_doesnt_exist_after_scenarios
+      omit "too slow now"
+
       assert_raise_message(/Expected the debuggee program to finish/) do
         prepare_test_environment(program, steps) do
           debug_code_on_tcpip()

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -157,7 +157,7 @@ module DEBUGGER__
     def create_scenario_and_program
       <<-TEST.chomp
 
-  class #{@class}#{@current_time} < TestCase
+  class #{@class}#{@current_time} < ConsoleTestCase
     def program
       <<~RUBY
         #{format_program}
@@ -477,7 +477,7 @@ module DEBUGGER__
           when /\[\>\]\s(.*)/
             begin
               req = JSON.parse $1
-            rescue JSON::ParserError => e
+            rescue JSON::ParserError
               $stderr.print data
               next
             end
@@ -504,7 +504,7 @@ module DEBUGGER__
           when /\[\<\]\s(.*)/
             begin
               res = JSON.parse $1
-            rescue JSON::ParserError => e
+            rescue JSON::ParserError
               $stderr.print data
               next
             end


### PR DESCRIPTION
1. This reverts 3 workarounds as they've been addressed upstream:
    - https://github.com/Shopify/debug/commit/8eea4c947e0dc5c131917cadef759664400a0e3d - upstream fix: https://github.com/ruby/debug/pull/920
    - https://github.com/Shopify/debug/commit/4313d91343c9b54039c3f87427b0eb9c7591f7a8 - upstream fix: https://github.com/ruby/debug/pull/944
    - https://github.com/Shopify/debug/commit/1e0f45c6578c29804177c8d22733017469f3db24 - upstream fix: https://github.com/ruby/debug/pull/947
2. And then it merges changes until the [v1.7.2 release](https://github.com/ruby/debug/releases/tag/v1.7.2)

So content-wise, it's now inline with the upsteam's `v1.7.2` release.

Note: https://github.com/ruby/debug/pull/947 didn't resolve the issue for DAP so I added https://github.com/ruby/debug/pull/950 for it, which I will open another PR to patch `issues-workaround` later.