### PR TITLE
WIP: Refactor `server_dap` to use command-registration style

### DIFF
--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -17,6 +17,7 @@ module DEBUGGER__
       @width = 80
       @repl = true
       @session = nil
+      @commands = {} # used in UI_DAP
     end
 
     class Terminate < StandardError; end


### PR DESCRIPTION
https://github.com/Shopify/ruby-dev-exp-issues/issues/840

FYI @st0012 

(I know this doesn't belong in `issues-workaround`, just branching off that for convenience).