### PR TITLE
Improve test process' kill signalling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,10 +149,10 @@ If the file already exists, **only method** will be added to it.
 ```ruby
 # frozen_string_literal: true
 
-require_relative '../support/test_case'
+require_relative '../support/console_test_case'
 
 module DEBUGGER__
-  class FooTest < TestCase
+  class FooTest < ConsoleTestCase
     def program
       <<~RUBY
         1| module Foo

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -425,8 +425,9 @@ module DEBUGGER__
     unless (dir_uid = fs.uid) == (uid = Process.uid)
       raise "#{path} uid is #{dir_uid}, but Process.uid is #{uid}"
     end
-    unless (dir_mode = fs.mode) == 040700 # 4: dir, 7:rwx
-      raise "#{path}'s mode is #{dir_mode.to_s(8)} (should be 040700)"
+
+    if fs.world_writable? && !fs.sticky?
+      raise "#{path} is world writable but not sticky"
     end
 
     path

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -468,6 +468,10 @@ module DEBUGGER__
       send_event :terminated unless @sock.closed?
     end
 
+    def request_rdbgRecordInspector req
+      @q_msg << req
+    end
+
     ## called by the SESSION thread
 
     def respond req, res
@@ -664,6 +668,43 @@ module DEBUGGER__
       end
     end
 
+    def request_rdbgRecordInspector req
+      cmd = req.dig('arguments', 'command')
+      case cmd
+      when 'enable'
+        request_tc [:record, :on]
+        @ui.respond req, {}
+      when 'disable'
+        request_tc [:record, :off]
+        @ui.respond req, {}
+      when 'step'
+        tid = req.dig('arguments', 'threadId')
+        count = req.dig('arguments', 'count')
+        if tc = find_waiting_tc(tid)
+          tc << [:step, :in, count]
+        else
+          fail_response req
+        end
+      when 'stepBack'
+        tid = req.dig('arguments', 'threadId')
+        count = req.dig('arguments', 'count')
+        if tc = find_waiting_tc(tid)
+          tc << [:step, :back, count]
+        else
+          fail_response req
+        end
+      when 'collect'
+        tid = req.dig('arguments', 'threadId')
+        if tc = find_waiting_tc(tid)
+          tc << [:dap, :rdbgRecordInspector, req]
+        else
+          fail_response req
+        end
+      else
+        raise "Unknown command #{cmd}"
+      end
+    end
+
     def dap_event args
       # puts({dap_event: args}.inspect)
       type, req, result = args
@@ -710,6 +751,10 @@ module DEBUGGER__
           @ui.respond req, result
         end
       when :completions
+        @ui.respond req, result
+
+      # custom request
+      when :rdbgRecordInspector
         @ui.respond req, result
       else
         raise "unsupported: #{args.inspect}"
@@ -979,6 +1024,26 @@ module DEBUGGER__
           raise "Unknown request: #{args.inspect}"
         end
       end
+    end
+
+    def request_rdbgRecordInspector req
+      logs = []
+      log_index = nil
+      unless @recorder.nil?
+        log_index = @recorder.log_index
+        @recorder.log.each{|frames|
+          crt_frame = frames[0]
+          logs << {
+            name: crt_frame.name,
+            location: {
+              path: crt_frame.location.path,
+              line: crt_frame.location.lineno,
+            },
+            depth: crt_frame.frame_depth
+          }
+        }
+      end
+      event! :dap_result, :rdbgRecordInspector, req, logs: logs, stoppedIndex: log_index
     end
 
     def search_const b, expr

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -973,7 +973,11 @@ module DEBUGGER__
         }
 
       else
-        raise "Unknown req: #{args.inspect}"
+        if respond_to? mid = "request_#{type}"
+          __send__ mid, req
+        else
+          raise "Unknown request: #{args.inspect}"
+        end
       end
     end
 

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -200,7 +200,7 @@ module DEBUGGER__
           # kill debug console process
           read.close
           write.close
-          kill_safely pid, :debugger, test_info
+          kill_safely pid
         end
       end
     end

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -334,9 +334,12 @@ module DEBUGGER__
 
       attach_to_dap_server
       scenario.call
+    rescue Test::Unit::AssertionFailedError => e
+      is_assertion_failure = true
+      raise e
     ensure
       kill_remote_debuggee test_info
-      if test_info.failed_process
+      if test_info.failed_process && !is_assertion_failure
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
@@ -365,9 +368,12 @@ module DEBUGGER__
       res = find_response :method, 'Debugger.paused', 'C<D'
       @crt_frames = res.dig(:params, :callFrames)
       scenario.call
+    rescue Test::Unit::AssertionFailedError => e
+      is_assertion_failure = true
+      raise e
     ensure
       kill_remote_debuggee test_info
-      if test_info.failed_process
+      if test_info.failed_process && !is_assertion_failure
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -338,8 +338,7 @@ module DEBUGGER__
       is_assertion_failure = true
       raise e
     ensure
-      kill_remote_debuggee test_info
-      if test_info.failed_process && !is_assertion_failure
+      if kill_remote_debuggee(test_info) && !is_assertion_failure
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
@@ -372,8 +371,7 @@ module DEBUGGER__
       is_assertion_failure = true
       raise e
     ensure
-      kill_remote_debuggee test_info
-      if test_info.failed_process && !is_assertion_failure
+      if kill_remote_debuggee(test_info) && !is_assertion_failure
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.

--- a/test/support/protocol_test_case_test.rb
+++ b/test/support/protocol_test_case_test.rb
@@ -3,14 +3,29 @@
 require_relative 'protocol_test_case'
 
 module DEBUGGER__
-  class TestFrameworkTestHOge < ProtocolTestCase
-    PROGRAM = <<~RUBY
-      1| a=1
-    RUBY
-
+  class TestProtocolTestCase < ProtocolTestCase
     def test_the_test_fails_when_debuggee_doesnt_exit
+      program = <<~RUBY
+        1| a=1
+      RUBY
+
       assert_fail_assertion do
-        run_protocol_scenario PROGRAM do
+        run_protocol_scenario program do
+        end
+      end
+    end
+
+    def test_the_assertion_failure_takes_presedence_over_debuggee_not_exiting
+      program = <<~RUBY
+        1| a = 2
+        2| b = 3
+      RUBY
+
+      assert_raise_message(/<\"100\"> expected but was/) do
+        run_protocol_scenario program do
+          req_add_breakpoint 2
+          req_continue
+          assert_repl_result({value: '100', type: 'Integer'}, 'a')
         end
       end
     end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -14,7 +14,7 @@ require_relative 'assertions'
 module DEBUGGER__
   class TestCase < Test::Unit::TestCase
     TestInfo = Struct.new(:queue, :mode, :prompt_pattern, :remote_info,
-                          :backlog, :last_backlog, :internal_info, :failed_process)
+                          :backlog, :last_backlog, :internal_info)
 
     RemoteInfo = Struct.new(:r, :w, :pid, :sock_path, :port, :reader_thread, :debuggee_backlog)
 

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -122,17 +122,17 @@ module DEBUGGER__
       true
     end
 
-    def kill_safely pid, name, test_info
-      return if wait_pid pid, TIMEOUT_SEC
-
-      test_info.failed_process = name
+    def kill_safely pid
+      return false if wait_pid pid, TIMEOUT_SEC
 
       Process.kill :TERM, pid
-      return if wait_pid pid, 0.2
+      return true if wait_pid pid, 0.2
 
       Process.kill :KILL, pid
       Process.waitpid(pid)
+      true
     rescue Errno::EPERM, Errno::ESRCH
+      true
     end
 
     def check_error(error, test_info)
@@ -142,13 +142,14 @@ module DEBUGGER__
     end
 
     def kill_remote_debuggee test_info
-      return unless r = test_info.remote_info
+      return false unless r = test_info.remote_info
 
-      kill_safely r.pid, :remote, test_info
+      force_killed = kill_safely r.pid
       r.reader_thread.kill
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_safely` method.
       r.r.close
       r.w.close
+     force_killed
     end
 
     def setup_remote_debuggee(cmd)

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -157,7 +157,7 @@ module DEBUGGER__
     def create_scenario_and_program
       <<-TEST.chomp
 
-  class #{@class}#{@current_time} < TestCase
+  class #{@class}#{@current_time} < ConsoleTestCase
     def program
       <<~RUBY
         #{format_program}


### PR DESCRIPTION
1. `remote_info.failed_process` stores symbol but we only use the value's presence to check if the process is force-killed.
2. The force-killed status is directly controlled by `kill_safely` through `kill_remote_debuggee`, which is directly called right before we check the status with `remote_info.failed_process`.

Combining the two, we can just let `kill_safely` and `kill_remote_debuggee` return the force-killed status and not storing it in `remote_info`, which already contains a bunch of information.

This also eliminates the need to pass `test_info` to `kill_safely`, which makes related code easier to understand and maintain.