### PR TITLE
Avoid locking all threads on debugger suspension

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1698,7 +1698,7 @@ module DEBUGGER__
         DEBUGGER__.debug{ "Enter subsession (nested #{@subsession_stack.size})" }
       else
         DEBUGGER__.debug{ "Enter subsession" }
-        stop_all_threads
+        # stop_all_threads
         @process_group.lock
       end
 


### PR DESCRIPTION
This commit stops locking all threads during suspension, which may prevent users from investigating threading problem. But it's still better than freezing the process just by running a ActiveRecord query, or doing anything that calls `Timeout.timeout`.

History around this issue:

1. It originally was reported in https://github.com/Shopify/ruby-dev-exp-issues/issues/724, and we reported it upstream too.
1. We introduced 1e0f45c6578c29804177c8d22733017469f3db24 as a workaround.
1. Upstream proposed a solution to fix the query evaluation case by restarting threads before evaluating console/DAP input. So the above commit was reverted.
1. However, the process could still hang if `Timeout.timeout` is called: 1. During a suspension 2. And outside of input evaluation An example is typing Arrow-up in the console as `reline` calls `Timeout.timeout` underneath.
1. So we need to reintroduce the workaround until we can find a better with the upstream maintainer.
