### PR TITLE
Avoid locking threads after input evaluation

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -342,8 +342,10 @@ module DEBUGGER__
           obj_inspect = ev_args[2]
           opt = ev_args[3]
           add_tracer ObjectTracer.new(@ui, obj_id, obj_inspect, **opt)
-        else
-          stop_all_threads
+        # We don't want to stop threads because it could cause deadlock with reline
+        # https://github.com/ruby/debug/issues/877#issuecomment-1516661829
+        # else
+          # stop_all_threads
         end
 
         wait_command_loop
@@ -1698,6 +1700,8 @@ module DEBUGGER__
         DEBUGGER__.debug{ "Enter subsession (nested #{@subsession_stack.size})" }
       else
         DEBUGGER__.debug{ "Enter subsession" }
+        # We don't want to stop threads because it could cause deadlock with reline
+        # https://github.com/ruby/debug/issues/877#issuecomment-1516661829
         # stop_all_threads
         @process_group.lock
       end


### PR DESCRIPTION
In #16, I removed the thread locking on suspension, but I missed the one that's after evaluation, which is what I comment out in this PR.

Otherwise, we'd still face the same problem as in #16, where the debugger would hang because the timeout thread is locked.