### PR TITLE
Autoload with Zeitwerk

### DIFF
--- a/debug.gemspec
+++ b/debug.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "irb", ">= 1.5.0" # for binding.irb(show_code: false)
   spec.add_dependency "reline", ">= 0.3.1"
+  spec.add_development_dependency "zeitwerk", "~> 2.6.9"
 end

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -142,7 +142,9 @@ module DEBUGGER__
       end
 
       if_updated old_conf, conf, :postmortem do |_, new_p|
-        if defined?(SESSION)
+        # puts("const_defined? #{ DEBUGGER__.const_defined?(:SESSION)}, defined? #{defined?(SESSION)}")
+        # if defined?(SESSION)
+        if DEBUGGER__.const_defined?(:SESSION)
           SESSION.postmortem = new_p
         end
       end
@@ -152,7 +154,8 @@ module DEBUGGER__
       end
 
       if_updated old_conf, conf, :no_sigint_hook do |old, new|
-        if defined?(SESSION)
+        # if defined?(SESSION)
+        if DEBUGGER__.const_defined?(:SESSION)
           SESSION.set_no_sigint_hook old, new
         end
       end

--- a/lib/debug/open.rb
+++ b/lib/debug/open.rb
@@ -6,6 +6,56 @@
 # If RUBY_DEBUG_PORT envval is provided (digits), open TCP/IP port.
 # Otherwise, UNIX domain socket is used.
 #
+require "awesome_print"
+require "pry"
+require "zeitwerk"
+
+module DEBUGGER__
+  # Define these dummy constants so we silence errors like:
+  #     expected file lib/debug/local.rb to define constant DEBUGGER__::Local, but didn't (Zeitwerk::NameError)
+  module Local; end
+  module Server; end
+  module ServerCdp; end
+  module ServerDap; end
+  module Version; end
+
+  # List special cases where constants are defined in files where they wouldn't otherwise be found
+  autoload(:CONFIG, "#{__dir__}/config.rb")
+  autoload(:SESSION, "#{__dir__}/config.rb")
+  # autoload(:NaiveString, "#{__dir__}/server_dap.rb")
+  autoload(:SkipPathHelper, "#{__dir__}/thread_client.rb")
+  autoload(:UI_Base, "#{__dir__}/session.rb")
+end
+
+loader = Zeitwerk::Loader.new
+loader.tag = File.basename(__FILE__, ".rb")
+loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
+# loader.push_dir(__dir__)
+
+loader.ignore(
+  "lib/debug/start.rb",
+  "lib/debug/open.rb",
+  "lib/debug/open_nonstop.rb",
+  "lib/debug/prelude.rb",
+  "lib/debug/dap_custom/traceInspector.rb"
+)
+
+# Configure a special-case for this mangled module name
+loader.push_dir(__dir__, namespace: DEBUGGER__)
+# loader.inflector.inflect(
+#   "debug" => "DEBUGGER__"
+# )
+
+loader.enable_reloading
+loader.setup
+loader.log!
+puts "Zeitwerk configured!"
+
+# ap({ roots: loader.send(:roots), ignored_paths: loader.send(:ignored_paths), all_paths: Zeitwerk::Loader.all_dirs })
+# loader.eager_load
+# puts("loaded constants under DEBUGGER__:")
+# ap(DEBUGGER__.constants)
+# exit(0)
 
 require_relative 'session'
 return unless defined?(DEBUGGER__)

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2212,7 +2212,7 @@ module DEBUGGER__
     CONFIG.set_config(**kw)
     require_relative 'server'
 
-    if defined? SESSION
+    if DEBUGGER__.const_defined?(:SESSION)
       SESSION.reset_ui UI_TcpServer.new(host: host, port: port)
     else
       initialize_session{ UI_TcpServer.new(host: host, port: port) }
@@ -2225,7 +2225,7 @@ module DEBUGGER__
     CONFIG.set_config(**kw)
     require_relative 'server'
 
-    if defined? SESSION
+    if DEBUGGER__::const_defined?(:SESSION)
       SESSION.reset_ui UI_UnixDomainServer.new(sock_dir: sock_dir, sock_path: sock_path)
     else
       initialize_session{ UI_UnixDomainServer.new(sock_dir: sock_dir, sock_path: sock_path) }
@@ -2376,7 +2376,7 @@ module DEBUGGER__
       @logfile = STDERR unless defined? @logfile
       return if @logfile.closed?
 
-      if defined? SESSION
+      if DEBUGGER__::const_defined?(:SESSION)
         pi = SESSION.process_info
         process_info = pi ? "[#{pi}]" : nil
       end


### PR DESCRIPTION
Constantly restarting your debugger to make your changes take effect is a total pain.

This PR tries to apply Zeitwerk to autoload constants and live reload files as they change (not yet working). I only do it to `open.rb`, and not other commands like `start.rb`.
