### PR TITLE
Cherry-pick commits to fix this branch on TruffleRuby

### DIFF
--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -1,0 +1,24 @@
+name: TruffleRuby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  truffleruby:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: truffleruby-head
+        bundler-cache: true
+    - name: Test installing the gem on TruffleRuby
+      run: |
+        bundle exec rake compile
+        bundle exec rake build
+        gem install pkg/debug-*.gem

--- a/ext/debug/debug.c
+++ b/ext/debug/debug.c
@@ -180,13 +180,17 @@ iseq_last_line(VALUE iseqw)
 }
 #endif
 
+#ifdef HAVE_RB_ISEQ
 void Init_iseq_collector(void);
+#endif
 
 void
 Init_debug(void)
 {
+#ifdef HAVE_RB_ISEQ
     VALUE rb_mRubyVM = rb_const_get(rb_cObject, rb_intern("RubyVM"));
     VALUE rb_cISeq = rb_const_get(rb_mRubyVM, rb_intern("InstructionSequence"));
+#endif
     rb_mDebugger = rb_const_get(rb_cObject, rb_intern("DEBUGGER__"));
     rb_cFrameInfo = rb_const_get(rb_mDebugger, rb_intern("FrameInfo"));
 
@@ -210,5 +214,7 @@ Init_debug(void)
     rb_define_method(rb_cISeq, "last_line", iseq_last_line, 0);
 #endif
 
+#ifdef HAVE_RB_ISEQ
     Init_iseq_collector();
+#endif
 }

--- a/ext/debug/extconf.rb
+++ b/ext/debug/extconf.rb
@@ -4,6 +4,7 @@ File.write("debug_version.h", "#define RUBY_DEBUG_VERSION \"#{DEBUGGER__::VERSIO
 $distcleanfiles << "debug_version.h"
 
 if defined? RubyVM
+  $defs << '-DHAVE_RB_ISEQ'
   $defs << '-DHAVE_RB_ISEQ_PARAMETERS'
   $defs << '-DHAVE_RB_ISEQ_CODE_LOCATION'
 

--- a/ext/debug/iseq_collector.c
+++ b/ext/debug/iseq_collector.c
@@ -1,5 +1,6 @@
 #include <ruby/ruby.h>
 
+#ifdef HAVE_RB_ISEQ
 VALUE rb_iseqw_new(VALUE v);
 void rb_objspace_each_objects(
     int (*callback)(void *start, void *end, size_t stride, void *data),
@@ -89,3 +90,4 @@ Init_iseq_collector(void)
     rb_define_singleton_method(rb_mObjSpace, "each_iseq", each_iseq, 0);
     rb_define_singleton_method(rb_mObjSpace, "count_iseq", count_iseq, 0);
 }
+#endif


### PR DESCRIPTION
This makes this branch of the gem installable on TruffleRuby.

The workaround for specific repos is to use `platform: :mri` in the Gemfile, but it would be nice to fix this branch.
It would also be good to rebase this work (if it is still necessary) against the master branch.
If it's not necessary, it would be good to delete so people do not adopt it in the future.